### PR TITLE
Fix for issue the-darkvoid#12 (performance regression)

### DIFF
--- a/BrcmPatchRAM.xcodeproj/project.pbxproj
+++ b/BrcmPatchRAM.xcodeproj/project.pbxproj
@@ -203,7 +203,7 @@
 		D4F91B071A2998CE0030D10D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CURRENT_PROJECT_VERSION = 1.5;
+				CURRENT_PROJECT_VERSION = 1.6;
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				SDKROOT = macosx10.6;
 			};
@@ -212,7 +212,7 @@
 		D4F91B081A2998CE0030D10D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CURRENT_PROJECT_VERSION = 1.5;
+				CURRENT_PROJECT_VERSION = 1.6;
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				SDKROOT = macosx10.6;
 			};

--- a/BrcmPatchRAM.xcodeproj/project.pbxproj
+++ b/BrcmPatchRAM.xcodeproj/project.pbxproj
@@ -203,7 +203,7 @@
 		D4F91B071A2998CE0030D10D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CURRENT_PROJECT_VERSION = 1.6.1;
+				CURRENT_PROJECT_VERSION = 1.6.2;
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				SDKROOT = macosx10.6;
 			};
@@ -212,7 +212,7 @@
 		D4F91B081A2998CE0030D10D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CURRENT_PROJECT_VERSION = 1.6.1;
+				CURRENT_PROJECT_VERSION = 1.6.2;
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				SDKROOT = macosx10.6;
 			};

--- a/BrcmPatchRAM.xcodeproj/project.pbxproj
+++ b/BrcmPatchRAM.xcodeproj/project.pbxproj
@@ -203,7 +203,7 @@
 		D4F91B071A2998CE0030D10D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CURRENT_PROJECT_VERSION = 1.4.1;
+				CURRENT_PROJECT_VERSION = 1.5;
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				SDKROOT = macosx10.6;
 			};
@@ -212,7 +212,7 @@
 		D4F91B081A2998CE0030D10D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CURRENT_PROJECT_VERSION = 1.4.1;
+				CURRENT_PROJECT_VERSION = 1.5;
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				SDKROOT = macosx10.6;
 			};
@@ -221,7 +221,6 @@
 		D4F91B0A1A2998CE0030D10D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CURRENT_PROJECT_VERSION = 1.5;
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				INFOPLIST_FILE = BrcmPatchRAM/Info.plist;
 				MODULE_NAME = "com.no-one.BrcmPatchRAM";
@@ -233,7 +232,6 @@
 		D4F91B0B1A2998CE0030D10D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CURRENT_PROJECT_VERSION = 1.5;
 				GCC_PREPROCESSOR_DEFINITIONS = "";
 				INFOPLIST_FILE = BrcmPatchRAM/Info.plist;
 				MODULE_NAME = "com.no-one.BrcmPatchRAM";

--- a/BrcmPatchRAM.xcodeproj/project.pbxproj
+++ b/BrcmPatchRAM.xcodeproj/project.pbxproj
@@ -203,7 +203,7 @@
 		D4F91B071A2998CE0030D10D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CURRENT_PROJECT_VERSION = 1.6;
+				CURRENT_PROJECT_VERSION = 1.6.1;
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				SDKROOT = macosx10.6;
 			};
@@ -212,7 +212,7 @@
 		D4F91B081A2998CE0030D10D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CURRENT_PROJECT_VERSION = 1.6;
+				CURRENT_PROJECT_VERSION = 1.6.1;
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				SDKROOT = macosx10.6;
 			};

--- a/BrcmPatchRAM.xcodeproj/project.pbxproj
+++ b/BrcmPatchRAM.xcodeproj/project.pbxproj
@@ -203,7 +203,7 @@
 		D4F91B071A2998CE0030D10D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CURRENT_PROJECT_VERSION = 1.6.2;
+				CURRENT_PROJECT_VERSION = 1.6.3;
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				SDKROOT = macosx10.6;
 			};
@@ -212,7 +212,7 @@
 		D4F91B081A2998CE0030D10D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CURRENT_PROJECT_VERSION = 1.6.2;
+				CURRENT_PROJECT_VERSION = 1.6.3;
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				SDKROOT = macosx10.6;
 			};

--- a/BrcmPatchRAM/BrcmFirmwareStore.cpp
+++ b/BrcmPatchRAM/BrcmFirmwareStore.cpp
@@ -344,7 +344,7 @@ OSArray* BrcmFirmwareStore::loadFirmware(OSString* firmwareKey)
         AlwaysLog("Non-compressed firmware.\n");
     
     OSArray* instructions = parseFirmware(firmwareData);
-    OSSafeRelease(firmwareData);
+    firmwareData->release();
     
     if (!instructions)
     {
@@ -377,7 +377,10 @@ OSArray* BrcmFirmwareStore::getFirmware(OSString* firmwareKey)
         
         // Add instructions to the firmwares cache
         if (instructions)
+        {
             mFirmwares->setObject(firmwareKey, instructions);
+            instructions->release();
+        }
     }
     else
      AlwaysLog("Retrieved cached firmware for \"%s\".\n", firmwareKey->getCStringNoCopy());

--- a/BrcmPatchRAM/BrcmFirmwareStore.cpp
+++ b/BrcmPatchRAM/BrcmFirmwareStore.cpp
@@ -180,6 +180,9 @@ OSArray* BrcmFirmwareStore::parseFirmware(OSData* firmwareData)
     UInt8 HCI_VSC_LAUNCH_RAM[] = { 0x4c, 0xfc };
     
     OSArray* instructions = OSArray::withCapacity(1);
+    if (!instructions)
+        return NULL;
+
     UInt8* data = (UInt8*)firmwareData->getBytesNoCopy();
     UInt32 address = 0;
     UInt8 binary[0x110];
@@ -231,6 +234,8 @@ OSArray* BrcmFirmwareStore::parseFirmware(OSData* firmwareData)
                 
                 // Allocate instruction (Opcode - 2 bytes, length - 1 byte)
                 OSData* instruction = OSData::withCapacity(3 + length);
+                if (!instruction)
+                    goto exit_error;
                 
                 instruction->appendBytes(HCI_VSC_LAUNCH_RAM, sizeof(HCI_VSC_LAUNCH_RAM));
                 instruction->appendBytes(&length, sizeof(length));
@@ -238,6 +243,7 @@ OSArray* BrcmFirmwareStore::parseFirmware(OSData* firmwareData)
                 instruction->appendBytes(&binary[4], length - 4);
                 
                 instructions->setObject(instruction);
+                instruction->release();
                 break;
             }
             // End of File

--- a/BrcmPatchRAM/BrcmPatchRAM.cpp
+++ b/BrcmPatchRAM/BrcmPatchRAM.cpp
@@ -120,6 +120,7 @@ IOService* BrcmPatchRAM::probe(IOService *provider, SInt32 *probeScore)
     mProductId = mDevice->GetProductID();
     
     uploadFirmware();
+    IOSleep(20);
     publishPersonality();
     
     clock_get_uptime(&end_time);

--- a/BrcmPatchRAM/BrcmPatchRAM.cpp
+++ b/BrcmPatchRAM/BrcmPatchRAM.cpp
@@ -229,9 +229,6 @@ IOReturn BrcmPatchRAM::setPowerState(unsigned long which, IOService *whom)
 
             // unpublish native bluetooth personality
             removePersonality();
-
-            // terminate this instance of BrcmPatchRAM (on wake, system will re-probe/start)
-            terminate();
         }
     }
 

--- a/BrcmPatchRAM/BrcmPatchRAM.cpp
+++ b/BrcmPatchRAM/BrcmPatchRAM.cpp
@@ -873,10 +873,12 @@ bool BrcmPatchRAM::performUpgrade()
                 continue;
 
             case kFirmwareWritten:
+                IOSleep(10);
                 hciCommand(&HCI_RESET, sizeof(HCI_RESET));
                 break;
 
             case kResetComplete:
+                IOSleep(10);
                 resetDevice();
                 getDeviceStatus();
                 mDeviceState = kUpdateComplete;

--- a/BrcmPatchRAM/BrcmPatchRAM.cpp
+++ b/BrcmPatchRAM/BrcmPatchRAM.cpp
@@ -159,16 +159,17 @@ void BrcmPatchRAM::stop(IOService* provider)
 
 void BrcmPatchRAM::uploadFirmware()
 {
+    // get firmware here to pre-cache for eventual use on wakeup or now
+    BrcmFirmwareStore* firmwareStore = getFirmwareStore();
+    OSArray* instructions = NULL;
+    if (!firmwareStore || !firmwareStore->getFirmware(OSDynamicCast(OSString, getProperty("FirmwareKey"))))
+        return;
+
     if (mDevice->open(this))
     {
         // Print out additional device information
         printDeviceInfo();
         
-        // get firmware here to pre-cache for eventual use on wakeup or now
-        BrcmFirmwareStore* firmwareStore = getFirmwareStore();
-        if (firmwareStore)
-            firmwareStore->getFirmware(OSDynamicCast(OSString, getProperty("FirmwareKey")));
-
         // Set device configuration to composite configuration index 0
         if (!setConfiguration(0))
         {

--- a/BrcmPatchRAM/BrcmPatchRAM.cpp
+++ b/BrcmPatchRAM/BrcmPatchRAM.cpp
@@ -363,9 +363,9 @@ void BrcmPatchRAM::publishPersonality()
                 AlwaysLog("[%04x:%04x]: ERROR in addDrivers for new IOKit personality.\n", mVendorId, mProductId);
             array->release();
         }
-        dict->release();
     }
-    
+    dict->release();
+
 #ifdef DEBUG
     printPersonalities();
 #endif

--- a/BrcmPatchRAM/BrcmPatchRAM.cpp
+++ b/BrcmPatchRAM/BrcmPatchRAM.cpp
@@ -101,7 +101,7 @@ IOService* BrcmPatchRAM::probe(IOService *provider, SInt32 *probeScore)
 
     mCompletionLock = IOLockAlloc();
     if (!mCompletionLock)
-        return false;
+        return NULL;
 
     mDevice = OSDynamicCast(IOUSBDevice, provider);
     if (!mDevice)

--- a/BrcmPatchRAM/BrcmPatchRAM.h
+++ b/BrcmPatchRAM/BrcmPatchRAM.h
@@ -64,7 +64,9 @@ private:
     volatile DeviceState mDeviceState = kInitialize;
     volatile uint16_t mFirmareVersion = 0xFFFF;
     
+#ifdef DEBUG
     static const char* getState(DeviceState deviceState);
+#endif
     static OSString* brcmBundleIdentifier;
     static OSString* brcmIOClass;
     static bool initBrcmStrings();
@@ -86,7 +88,7 @@ private:
     IOUSBInterface* findInterface();
     IOUSBPipe* findPipe(uint8_t type, uint8_t direction);
     
-    void continousRead();
+    void continuousRead();
     static void readCompletion(void* target, void* parameter, IOReturn status, UInt32 bufferSizeRemaining);
     
     IOReturn hciCommand(void * command, uint16_t length);

--- a/BrcmPatchRAM/BrcmPatchRAM.h
+++ b/BrcmPatchRAM/BrcmPatchRAM.h
@@ -40,7 +40,8 @@ enum DeviceState
     kInstructionWritten,
     kFirmwareWritten,
     kResetComplete,
-    kUpdateComplete
+    kUpdateComplete,
+    kUpdateAborted,
 };
 
 class BrcmPatchRAM : public IOService
@@ -63,6 +64,7 @@ private:
     
     volatile DeviceState mDeviceState = kInitialize;
     volatile uint16_t mFirmareVersion = 0xFFFF;
+    IOLock* mCompletionLock = NULL;
     
 #ifdef DEBUG
     static const char* getState(DeviceState deviceState);
@@ -88,7 +90,7 @@ private:
     IOUSBInterface* findInterface();
     IOUSBPipe* findPipe(uint8_t type, uint8_t direction);
     
-    void continuousRead();
+    bool continuousRead();
     static void readCompletion(void* target, void* parameter, IOReturn status, UInt32 bufferSizeRemaining);
     
     IOReturn hciCommand(void * command, uint16_t length);

--- a/BrcmPatchRAM/BrcmPatchRAM.h
+++ b/BrcmPatchRAM/BrcmPatchRAM.h
@@ -29,6 +29,7 @@
 #define kBundleIdentifier "CFBundleIdentifier"
 #define kIOUSBDeviceClassName "IOUSBDevice"
 #define kAppleBundlePrefix "com.apple."
+#define kFirmwareKey "FirmwareKey"
 
 enum DeviceState
 {

--- a/BrcmPatchRAM/BrcmPatchRAM.h
+++ b/BrcmPatchRAM/BrcmPatchRAM.h
@@ -96,7 +96,7 @@ private:
     IOReturn hciCommand(void * command, uint16_t length);
     IOReturn hciParseResponse(void* response, uint16_t length, void* output, uint8_t* outputLength);
     
-    IOReturn bulkWrite(void* data, uint16_t length);
+    IOReturn bulkWrite(const void* data, uint16_t length);
     
     uint16_t getFirmwareVersion();
     

--- a/BrcmPatchRAM/Info.plist
+++ b/BrcmPatchRAM/Info.plist
@@ -25,7 +25,7 @@
             <key>CFBundleIdentifier</key>
             <string>com.no-one.$(PRODUCT_NAME:rfc1034identifier)</string>
             <key>DisplayName</key>
-            <string>Azurewave BCM943225 (20702A built-in firmwaer)</string>
+            <string>Azurewave BCM943225 (20702A built-in firmware)</string>
             <key>#FirmwareKey</key>
             <string>only load and unload native bluetooth</string>
             <key>IOClass</key>

--- a/BrcmPatchRAM/Info.plist
+++ b/BrcmPatchRAM/Info.plist
@@ -20,6 +20,25 @@
 	<string>${CURRENT_PROJECT_VERSION}</string>
 	<key>IOKitPersonalities</key>
 	<dict>
+        <key>13d3_3295</key>
+        <dict>
+            <key>CFBundleIdentifier</key>
+            <string>com.no-one.$(PRODUCT_NAME:rfc1034identifier)</string>
+            <key>DisplayName</key>
+            <string>Azurewave BCM943225 (20702A built-in firmwaer)</string>
+            <key>#FirmwareKey</key>
+            <string>only load and unload native bluetooth</string>
+            <key>IOClass</key>
+            <string>BrcmPatchRAM</string>
+            <key>IOMatchCategory</key>
+            <string>BrcmPatchRAM</string>
+            <key>IOProviderClass</key>
+            <string>IOUSBDevice</string>
+            <key>idProduct</key>
+            <integer>12949</integer>
+            <key>idVendor</key>
+            <integer>5075</integer>
+        </dict>
 		<key>0489_e032</key>
 		<dict>
 			<key>CFBundleIdentifier</key>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+###BrcmPatchRAM -- RehabMan fork
+
+This version of BrcmPatchRAM contains several fixes as compared with the current release from the-darkvoid:
+
+* firmware loading is more than 3x faster than the-darkvoid version (~0.5s vs. ~1.77s)
+* bluetooth is ready instantly after wake from sleep (by unregistering/unloading pre-sleep)
+* pre-cache uncompressed firmware in probe even when firmware is already resident (helps for faster wakeup)
+* fixed various memory leaks and unhandled out-of-memory conditions
+* this version can be used with non-RAMUSB Broadcom devices (results in quicker bluetooth activating after wake from sleep)
+
+It is assumed that eventually the-darkvoid will merge my changes into his version.
+
+Downloads are available on bitbucket: https://bitbucket.org/RehabMan/os-x-brcmpatchram/downloads
+
+
 ###BrcmPatchRAM
 
 __Note if you have an Apple MacBook/iMac/Mac Pro etc, follow the [Mac instructions](https://github.com/robvanoostenrijk/BrcmPatchRAM/blob/master/README-Mac.md)__


### PR DESCRIPTION
It seems to be working well for me here.  The final addition of the IOSleep calls seem to fix some intermittent problems I was having (where firmware was loaded but native BT driver didn't work).  The IOSleep calls are conservative (10ms each) compared to the original code (5ms, 100ms, 50ms).

Please test and provide feedback.

Link to performance issue: https://github.com/the-darkvoid/BrcmPatchRAM/issues/12