### PR TITLE
Fix for intermittent bluetooth failure after sleep/wake cycle

### DIFF
--- a/BrcmPatchRAM.xcodeproj/project.pbxproj
+++ b/BrcmPatchRAM.xcodeproj/project.pbxproj
@@ -203,7 +203,7 @@
 		D4F91B071A2998CE0030D10D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CURRENT_PROJECT_VERSION = 1.6.3;
+				CURRENT_PROJECT_VERSION = 1.7;
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				SDKROOT = macosx10.6;
 			};
@@ -212,7 +212,7 @@
 		D4F91B081A2998CE0030D10D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CURRENT_PROJECT_VERSION = 1.6.3;
+				CURRENT_PROJECT_VERSION = 1.7;
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				SDKROOT = macosx10.6;
 			};

--- a/BrcmPatchRAM/BrcmFirmwareStore.cpp
+++ b/BrcmPatchRAM/BrcmFirmwareStore.cpp
@@ -389,7 +389,7 @@ OSArray* BrcmFirmwareStore::getFirmware(OSString* firmwareKey)
         }
     }
     else
-     AlwaysLog("Retrieved cached firmware for \"%s\".\n", firmwareKey->getCStringNoCopy());
+     DebugLog("Retrieved cached firmware for \"%s\".\n", firmwareKey->getCStringNoCopy());
     
     return instructions;
 }

--- a/BrcmPatchRAM/BrcmPatchRAM.cpp
+++ b/BrcmPatchRAM/BrcmPatchRAM.cpp
@@ -99,6 +99,10 @@ IOService* BrcmPatchRAM::probe(IOService *provider, SInt32 *probeScore)
 
     clock_get_uptime(&start_time);
 
+    mWorkLock = IOLockAlloc();
+    if (!mWorkLock)
+        return NULL;
+
     mCompletionLock = IOLockAlloc();
     if (!mCompletionLock)
         return NULL;
@@ -118,7 +122,11 @@ IOService* BrcmPatchRAM::probe(IOService *provider, SInt32 *probeScore)
     
     mVendorId = mDevice->GetVendorID();
     mProductId = mDevice->GetProductID();
-    
+
+    // get firmware here to pre-cache for eventual use on wakeup or now
+    if (BrcmFirmwareStore* firmwareStore = getFirmwareStore())
+        firmwareStore->getFirmware(OSDynamicCast(OSString, getProperty(kFirmwareKey)));
+
     uploadFirmware();
     publishPersonality();
 
@@ -137,6 +145,28 @@ bool BrcmPatchRAM::start(IOService *provider)
     if (!super::start(provider))
         return false;
     
+    // add interrupt source for delayed actions...
+    IOWorkLoop* workLoop = getWorkLoop();
+    if (!workLoop)
+        return false;
+    mWorkSource = IOInterruptEventSource::interruptEventSource(this, OSMemberFunctionCast(IOInterruptEventAction, this, &BrcmPatchRAM::processWorkQueue));
+    if (!mWorkSource)
+        return false;
+    workLoop->addEventSource(mWorkSource);
+    mWorkPending = 0;
+
+    // add timer for firmware load in the case no re-probe after wake
+    mTimer = IOTimerEventSource::timerEventSource(this, OSMemberFunctionCast(IOTimerEventSource::Action, this, &BrcmPatchRAM::onTimerEvent));
+    if (!mTimer)
+    {
+        workLoop->removeEventSource(mWorkSource);
+        mWorkSource->release();
+        mWorkSource = NULL;
+        return false;
+    }
+    workLoop->addEventSource(mTimer);
+
+    // register for power state notifications
     PMinit();
     registerPowerDriver(this, myTwoStates, 2);
     provider->joinPMtree(this);
@@ -144,11 +174,39 @@ bool BrcmPatchRAM::start(IOService *provider)
     return true;
 }
 
+static uint64_t wake_time;
+
 void BrcmPatchRAM::stop(IOService* provider)
 {
+    uint64_t stop_time, nano_secs;
+    clock_get_uptime(&stop_time);
+    absolutetime_to_nanoseconds(stop_time - wake_time, &nano_secs);
+    uint64_t milli_secs = nano_secs / 1000000;
+    AlwaysLog("Time since wake %llu.%llu seconds.\n", milli_secs / 1000, milli_secs % 1000);
+
+
     DebugLog("stop\n");
 
     OSSafeReleaseNULL(mFirmwareStore);
+
+    IOWorkLoop* workLoop = getWorkLoop();
+    if (workLoop)
+    {
+        if (mTimer)
+        {
+            mTimer->cancelTimeout();
+            workLoop->removeEventSource(mTimer);
+            mTimer->release();
+            mTimer = NULL;
+        }
+        if (mWorkSource)
+        {
+            workLoop->removeEventSource(mWorkSource);
+            mWorkSource->release();
+            mWorkSource = NULL;
+            mWorkPending = 0;
+        }
+    }
 
     PMstop();
 
@@ -157,19 +215,91 @@ void BrcmPatchRAM::stop(IOService* provider)
         IOLockFree(mCompletionLock);
         mCompletionLock = NULL;
     }
+    if (mWorkLock)
+    {
+        IOLockFree(mWorkLock);
+        mWorkLock = NULL;
+    }
 
     OSSafeReleaseNULL(mDevice);
 
     super::stop(provider);
 }
 
+IOReturn BrcmPatchRAM::onTimerEvent()
+{
+    DebugLog("onTimerEvent\n");
+
+    if (!mDevice->getProperty(kFirmwareLoaded))
+    {
+        AlwaysLog("BLURP!! no firmware loaded and timer expiried (no re-probe)\n");
+        scheduleWork(kWorkLoadFirmware);
+    }
+
+    return kIOReturnSuccess;
+}
+
+void BrcmPatchRAM::scheduleWork(unsigned int newWork)
+{
+    IOLockLock(mWorkLock);
+    mWorkPending |= newWork;
+    mWorkSource->interruptOccurred(0, 0, 0);
+    IOLockUnlock(mWorkLock);
+}
+
+void BrcmPatchRAM::processWorkQueue(IOInterruptEventSource*, int)
+{
+    IOLockLock(mWorkLock);
+
+    // start firmware loading process in a non-workloop thread
+    if (mWorkPending & kWorkLoadFirmware)
+    {
+        DebugLog("_workPending kWorkLoadFirmare\n");
+        mWorkPending &= ~kWorkLoadFirmware;
+        retain();
+        kern_return_t result = kernel_thread_start(&BrcmPatchRAM::uploadFirmwareThread, this, &mWorker);
+        if (KERN_SUCCESS == result)
+            DebugLog("Success creating firmware uploader thread\n");
+        else
+        {
+            AlwaysLog("ERROR creating firmware uploader thread.\n");
+            release();
+        }
+    }
+
+    // firmware loading thread is finished
+    if (mWorkPending & kWorkFinished)
+    {
+        DebugLog("_workPending kWorkFinished\n");
+        mWorkPending &= ~kWorkFinished;
+        thread_deallocate(mWorker);
+        mWorker = 0;
+        release();  // matching retain when thread created successfully
+    }
+
+    IOLockUnlock(mWorkLock);
+}
+
+void BrcmPatchRAM::uploadFirmwareThread(void *arg, wait_result_t wait)
+{
+    DebugLog("sendFirmwareThread enter\n");
+
+    BrcmPatchRAM* me = static_cast<BrcmPatchRAM*>(arg);
+    me->resetDevice();
+    IOSleep(20);
+    me->uploadFirmware();
+    me->publishPersonality();
+    me->scheduleWork(kWorkFinished);
+
+    DebugLog("sendFirmwareThread termination\n");
+    thread_terminate(current_thread());
+    DebugLog("!!! sendFirmwareThread post-terminate !!! should not be here\n");
+}
+
 void BrcmPatchRAM::uploadFirmware()
 {
-    // get firmware here to pre-cache for eventual use on wakeup or now
-    BrcmFirmwareStore* firmwareStore = getFirmwareStore();
-    OSArray* instructions = NULL;
-    if (!firmwareStore || !firmwareStore->getFirmware(OSDynamicCast(OSString, getProperty(kFirmwareKey))))
-        return;
+    // signal to timer that firmware already loaded
+    mDevice->setProperty(kFirmwareLoaded, true);
 
     if (mDevice->open(this))
     {
@@ -217,19 +347,29 @@ IOReturn BrcmPatchRAM::setPowerState(unsigned long which, IOService *whom)
     
     if (which == kMyOffPowerState)
     {
+        // consider firmware no longer loaded
+        mDevice->removeProperty(kFirmwareLoaded);
+
         // in the case the instance is shutting down, don't do anything
         if (mFirmwareStore)
         {
             // unload native bluetooth driver
             IOReturn result = gIOCatalogue->terminateDriversForModule(brcmBundleIdentifier, false);
             if (result != kIOReturnSuccess)
-                AlwaysLog("[%04x:%04x]: failure terminating native Broadcom bluetooth (%08x)", mVendorId, mProductId, result);
+                AlwaysLog("[%04x:%04x]: failure terminating native Broadcom bluetooth (%08x)\n", mVendorId, mProductId, result);
             else
                 DebugLog("[%04x:%04x]: success terminating native Broadcom bluetooth\n", mVendorId, mProductId);
 
             // unpublish native bluetooth personality
             removePersonality();
         }
+    }
+    else if (which == kMyOnPowerState)
+    {
+        clock_get_uptime(&wake_time);
+        // start loading firmware for case probe is never called after wake
+        if (!mDevice->getProperty(kFirmwareLoaded))
+            mTimer->setTimeoutMS(400); // longest time seen in normal re-probe was ~200ms
     }
 
     return IOPMAckImplied;


### PR DESCRIPTION
As noted in the README.md:

This version (v1.7) of BrcmPatchRAM has a fix for a problem I noticed on my Lenovo u430.

Description of the problem: Intermittently, bluetooth would not be available after a sleep/wake cycle. The problem turns out that sometimes Yosemite doesn't "tear down" and "reconstruct" the USB (either EHC or XHC) ioreg tree after wake. This results in the instance of BrcmPatchRAM that was resident prior to sleep to remain resident and attached to the bluetooth device. This means no call to ::probe will be made and thus no firmware loaded into the device. The problem was observed intermittently, approx. 1 of 25 wakes.

The fix: Since the device has no firmware and no reprobe will be happening in that case, we need to load firmware after the wake notification is received but not before we know that a re-probe is not going to occur. By intrumenting ::stop, it was determined that, in normal cases, the device is reconstructed (thus old instance gets ::stop, new instance gets ::probe) within approx 100-200ms. The solution, then, is to create a timer on wake and should the timer expire (before ::stop is called), spin up a thread to load firmware. The timer used currently is 400ms. The longest time between wake and reprobe (non failure case) was 214ms.

I mention the specific timing as I don't believe the code will deal gracefully if a USB teardown happens in the middle of firmware uploading. I will look at improving the robustness in the (near) future. This version has been tested on my u430 over many sleep/wake cycles without issue. No instances of failed bluetooth after sleep, and no crashes caused by the firmware uploader thread.