### PR TITLE
The event passed to IOLockSleep/IOLockWakeup can not be NULL

### DIFF
--- a/BrcmPatchRAM/BrcmPatchRAM.cpp
+++ b/BrcmPatchRAM/BrcmPatchRAM.cpp
@@ -764,7 +764,7 @@ void BrcmPatchRAM::readCompletion(void* target, void* parameter, IOReturn status
     IOLockUnlock(me->mCompletionLock);
 
     // wake waiting task in performUpgrade (in IOLockSleep)...
-    IOLockWakeup(me->mCompletionLock, NULL, true);
+    IOLockWakeup(me->mCompletionLock, &me->workerEvent, true);
 }
 
 IOReturn BrcmPatchRAM::hciCommand(void * command, UInt16 length)
@@ -1039,7 +1039,7 @@ bool BrcmPatchRAM::performUpgrade()
             continue;
         }
         // wait for completion of the async read
-        IOLockSleep(mCompletionLock, NULL, 0);
+        IOLockSleep(mCompletionLock, &workerEvent, 0);
     }
 
     IOLockUnlock(mCompletionLock);

--- a/BrcmPatchRAM/BrcmPatchRAM.h
+++ b/BrcmPatchRAM/BrcmPatchRAM.h
@@ -85,6 +85,7 @@ private:
 
     static void uploadFirmwareThread(void* arg, wait_result_t wait);
     thread_t mWorker = 0;
+    void *workerEvent;
 
     IOInterruptEventSource* mWorkSource = NULL;
     IOLock* mWorkLock = NULL;


### PR DESCRIPTION
A NULL event causes a kernel panic with 10.10.3 and probably other
versions.

Signed-off-by: Nathan Hjelm <hjelmn@me.com>