### PR TITLE
Fix for Not responding - Delaying next read/device request failed/continuousRead - Failed to queue read

### DIFF
--- a/BrcmNonPatchRAM-Info.plist
+++ b/BrcmNonPatchRAM-Info.plist
@@ -37,6 +37,25 @@
 			<key>idVendor</key>
 			<integer>1008</integer>
 		</dict>
+		<key>0489_e030 no firmware legacy - 2</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.no-one.$(PRODUCT_NAME:rfc1034identifier)</string>
+			<key>DisplayName</key>
+			<string>Foxconn AW-NB290</string>
+			<key>#FirmwareKey</key>
+			<string>only load and unload native bluetooth</string>
+			<key>IOClass</key>
+			<string>BrcmPatchRAM</string>
+			<key>IOMatchCategory</key>
+			<string>BrcmPatchRAM</string>
+			<key>IOProviderClass</key>
+			<string>IOUSBDevice</string>
+			<key>idProduct</key>
+			<integer>57392</integer>
+			<key>idVendor</key>
+			<integer>1161</integer>
+		</dict>
 		<key>0a5c_219a no firmware legacy</key>
 		<dict>
 			<key>CFBundleIdentifier</key>

--- a/BrcmNonPatchRAM-Info.plist
+++ b/BrcmNonPatchRAM-Info.plist
@@ -37,6 +37,25 @@
 			<key>idVendor</key>
 			<integer>1008</integer>
 		</dict>
+		<key>0a5c_219a no firmware legacy</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.no-one.$(PRODUCT_NAME:rfc1034identifier)</string>
+			<key>DisplayName</key>
+			<string>Broadcom BCM2070 0a5c_219a (BT on BCM43225HMB)</string>
+			<key>#FirmwareKey</key>
+			<string>only load and unload native bluetooth</string>
+			<key>IOClass</key>
+			<string>BrcmPatchRAM</string>
+			<key>IOMatchCategory</key>
+			<string>BrcmPatchRAM</string>
+			<key>IOProviderClass</key>
+			<string>IOUSBDevice</string>
+			<key>idProduct</key>
+			<integer>2652</integer>
+			<key>idVendor</key>
+			<integer>8602</integer>
+		</dict>
 		<key>0b05_178a no firmware legacy</key>
 		<dict>
 			<key>CFBundleIdentifier</key>

--- a/BrcmNonPatchRAM2-Info.plist
+++ b/BrcmNonPatchRAM2-Info.plist
@@ -50,6 +50,38 @@
 			<key>idVendor</key>
 			<integer>1008</integer>
 		</dict>
+		<key>0489_e030 no firmware</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.no-one.$(PRODUCT_NAME:rfc1034identifier)</string>
+			<key>DisplayName</key>
+			<string>Foxconn AW-NB290</string>
+			<key>#FirmwareKey</key>
+			<string>only load and unload native bluetooth</string>
+			<key>IOClass</key>
+			<string>BrcmPatchRAM2</string>
+			<key>IOMatchCategory</key>
+			<string>BrcmPatchRAM2</string>
+			<key>IOProviderClass</key>
+			<string>IOUSBHostDevice</string>
+			<key>idProduct</key>
+			<integer>57392</integer>
+			<key>idVendor</key>
+			<integer>1161</integer>
+		</dict>
+		<key>0489_e030 native</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.apple.iokit.BroadcomBluetoothHostControllerUSBTransport</string>
+			<key>IOClass</key>
+			<string>BroadcomBluetoothHostControllerUSBTransport</string>
+			<key>IOProviderClass</key>
+			<string>IOUSBHostDevice</string>
+			<key>idProduct</key>
+			<integer>57392</integer>
+			<key>idVendor</key>
+			<integer>1161</integer>
+		</dict>
 		<key>0a5c_219a no firmware</key>
 		<dict>
 			<key>CFBundleIdentifier</key>

--- a/BrcmNonPatchRAM2-Info.plist
+++ b/BrcmNonPatchRAM2-Info.plist
@@ -50,6 +50,38 @@
 			<key>idVendor</key>
 			<integer>1008</integer>
 		</dict>
+		<key>0a5c_219a no firmware</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.no-one.$(PRODUCT_NAME:rfc1034identifier)</string>
+			<key>DisplayName</key>
+			<string>Broadcom BCM2070 0a5c_219a (BT on BCM43225HMB)</string>
+			<key>#FirmwareKey</key>
+			<string>only load and unload native bluetooth</string>
+			<key>IOClass</key>
+			<string>BrcmPatchRAM2</string>
+			<key>IOMatchCategory</key>
+			<string>BrcmPatchRAM2</string>
+			<key>IOProviderClass</key>
+			<string>IOUSBHostDevice</string>
+			<key>idProduct</key>
+			<integer>2652</integer>
+			<key>idVendor</key>
+			<integer>8602</integer>
+		</dict>
+		<key>0a5c_219a native</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.apple.iokit.BroadcomBluetoothHostControllerUSBTransport</string>
+			<key>IOClass</key>
+			<string>BroadcomBluetoothHostControllerUSBTransport</string>
+			<key>IOProviderClass</key>
+			<string>IOUSBHostDevice</string>
+			<key>idProduct</key>
+			<integer>2652</integer>
+			<key>idVendor</key>
+			<integer>8602</integer>
+		</dict>
 		<key>0b05_1788 no firmware</key>
 		<dict>
 			<key>CFBundleIdentifier</key>

--- a/BrcmPatchRAM.xcodeproj/project.pbxproj
+++ b/BrcmPatchRAM.xcodeproj/project.pbxproj
@@ -1263,7 +1263,7 @@
 		D4F91B071A2998CE0030D10D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CURRENT_PROJECT_VERSION = 2.2.7;
+				CURRENT_PROJECT_VERSION = 2.2.8;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				SDKROOT = macosx10.6;
@@ -1274,7 +1274,7 @@
 		D4F91B081A2998CE0030D10D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CURRENT_PROJECT_VERSION = 2.2.7;
+				CURRENT_PROJECT_VERSION = 2.2.8;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				SDKROOT = macosx10.6;

--- a/README-Mac.md
+++ b/README-Mac.md
@@ -23,7 +23,7 @@ Take the following steps in the Terminal:
   ```  
  * Reboot the Mac   
 
-Note: In 10.11, you must disable SIP. Refer to Apple provided documentation for disabling SIP (hint: use csrutil in Recovery).
+Note: In 10.11 and later, you must disable SIP before attempting to modify NVRAM. Refer to Apple provided documentation for disabling SIP (hint: use csrutil in Recovery).
 
 For OS X older than 10.11, install the required kexts inside /System/Library/Extensions.
 ```
@@ -32,7 +32,7 @@ sudo cp -R ~/Downloads/BrcmFirmwareRepo.kext /System/Library/Extensions
 sudo touch /System/Library/Extensions
 ```
 
-Or for 10.11, to /Library/Extensions:
+Or for 10.11 and later, to /Library/Extensions:
 ```
 sudo cp -R ~/Downloads/BrcmPatchRAM2.kext /Library/Extensions
 sudo cp -R ~/Downloads/BrcmFirmwareRepo.kext /Library/Extensions

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ Note that the original Apple Broadcom bluetooth devices are not RAMUSB devices, 
 
 To be used for OS X 10.11 or newer.
 
-This kext is a simple injector... it does not contain a firmware uploader.  Try this kext if you wish to see if the built-in firmware uploader in 10.11+ will work for your device.
+This kext is a simple injector... it does not contain a firmware uploader.  Try this kext if you wish to see if your device will work without a firmware uploader.
 
 Do not use any of the other kexts (BrcmPatchRAM, BrcmPatchRAM2, BrcmFirmwareRepo, or BrcmFirmwareData) with this kext.
 
-This kext is not provided in the distribution ZIP.  You can build it if you wish to try it.  It was removed as it presense was causing confusion for those that don't read carefully and didn't install the preferred kexts correctly.
+This kext is not provided in the distribution ZIP.  You can build it if you wish to try it.  It was removed as it presense was causing confusion for those that don't read carefully and didn't install the preferred kexts correctly.  It is not currently being updated with new devices.  If yours is not present, edit the Info.plist as needed.
 
 
 ####Supported Devices

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ For the most part this fork is kept in sync with the-darkvoid's verson.  We are 
 
 ###RehabMan Fork Downloads
 
-Builds are available on bitbucket: https://bitbucket.org/RehabMan/os-x-brcmpatchram/downloads
+Builds are available on bitbucket: https://bitbucket.org/RehabMan/os-x-brcmpatchram/downloads/
 
 
 ###Installation


### PR DESCRIPTION
I have managed to fix one very strange issue: after a numerous cycles of sleep/wake my bluetooth stopped working, in log I discovered:
(kernel) BrcmPatchRAM2: [13d3:3404]: Not responding - Delaying next read.
(kernel) BrcmPatchRAM2: [13d3:3404]: device request failed ("0xe00002ed (UNDEFINED)" 0xe00002ed).
(kernel) BrcmPatchRAM2: [13d3:3404]: Not responding - Delaying next read.
(kernel) BrcmPatchRAM2: [13d3:3404]: device request failed ("0xe00002d8 (UNDEFINED)" 0xe00002d8).
 (kernel) BrcmPatchRAM2: [13d3:3404]: continuousRead - Failed to queue read (0xe00002d8)

I had a look to the IOReg and saw two devices with the same name: BCM20702A0, but they had different sessionID.
My fix is quite simple (I believe you could improve it): get the root provider for current BCM20702A0 device, iterate over all client and try to perform a firmware upgrade for all of them.